### PR TITLE
Add a function to create cloze from word under cursor

### DIFF
--- a/anki-editor.el
+++ b/anki-editor.el
@@ -658,12 +658,11 @@ same as how it is used by `M-RET'(org-insert-heading)."
                                        note-type
                                        fields)))
 
-(defun anki-editor-cloze-region (&optional arg)
+(defun anki-editor-cloze-region (&optional arg hint)
   "Cloze region with number ARG."
-  (interactive "p")
+  (interactive "p\nsHint (optional): ")
   (unless (region-active-p) (error "No active region"))
-  (let ((region (buffer-substring (region-beginning) (region-end)))
-        (hint (read-from-minibuffer "Hint (optional): ")))
+  (let ((region (buffer-substring (region-beginning) (region-end))))
     (save-excursion
       (delete-region (region-beginning) (region-end))
       (insert (with-output-to-string

--- a/anki-editor.el
+++ b/anki-editor.el
@@ -664,6 +664,15 @@ same as how it is used by `M-RET'(org-insert-heading)."
   (unless (region-active-p) (error "No active region"))
   (anki-editor-cloze (region-beginning) (region-end)))
 
+(defun anki-editor-cloze-dwim (&optional arg hint)
+  "Cloze current active region or a word the under the cursor"
+  (interactive "p\nsHint (optional): ")
+  (cond
+   ((region-active-p) (anki-editor-cloze (region-beginning) (region-end)))
+   ((thing-at-point 'word) (let ((bounds (bounds-of-thing-at-point 'word)))
+                             (anki-editor-cloze (car bounds) (cdr bounds) arg hint)))
+   (t (error "Nothing to create cloze from"))))
+
 (defun anki-editor-cloze (begin end arg hint)
   "Cloze region from BEGIN to END with number ARG."
   (let ((region (buffer-substring begin end)))

--- a/anki-editor.el
+++ b/anki-editor.el
@@ -662,9 +662,13 @@ same as how it is used by `M-RET'(org-insert-heading)."
   "Cloze region with number ARG."
   (interactive "p\nsHint (optional): ")
   (unless (region-active-p) (error "No active region"))
-  (let ((region (buffer-substring (region-beginning) (region-end))))
+  (anki-editor-cloze (region-beginning) (region-end)))
+
+(defun anki-editor-cloze (begin end arg hint)
+  "Cloze region from BEGIN to END with number ARG."
+  (let ((region (buffer-substring begin end)))
     (save-excursion
-      (delete-region (region-beginning) (region-end))
+      (delete-region begin end)
       (insert (with-output-to-string
                 (princ (format "{{c%d::%s" (or arg 1) region))
                 (unless (string-blank-p hint) (princ (format "::%s" hint)))


### PR DESCRIPTION
This PR adds function anki-editor-cloze-dwim which creates cloze from selected text or from the word under cursor.