### PR TITLE
Fixed function call of anki-editor-cloze from anki-editor-cloze-region/dwim

### DIFF
--- a/anki-editor.el
+++ b/anki-editor.el
@@ -690,7 +690,7 @@ same as how it is used by `M-RET'(org-insert-heading)."
   "Cloze region with number ARG."
   (interactive "p\nsHint (optional): ")
   (unless (region-active-p) (error "No active region"))
-  (anki-editor-cloze (region-beginning) (region-end)))
+  (anki-editor-cloze (region-beginning) (region-end) arg hint))
 
 (defun anki-editor-cloze-dwim (&optional arg hint)
   "Cloze current active region or a word the under the cursor"

--- a/anki-editor.el
+++ b/anki-editor.el
@@ -696,7 +696,7 @@ same as how it is used by `M-RET'(org-insert-heading)."
   "Cloze current active region or a word the under the cursor"
   (interactive "p\nsHint (optional): ")
   (cond
-   ((region-active-p) (anki-editor-cloze (region-beginning) (region-end)))
+   ((region-active-p) (anki-editor-cloze (region-beginning) (region-end) arg hint))
    ((thing-at-point 'word) (let ((bounds (bounds-of-thing-at-point 'word)))
                              (anki-editor-cloze (car bounds) (cdr bounds) arg hint)))
    (t (error "Nothing to create cloze from"))))


### PR DESCRIPTION
Hello,
when I used the functions anki-editor-cloze-region/dwim, I got error messages. 

> anki-editor-cloze-region: Wrong number of arguments: (4 . 4), 2

Putting arg and hint into the function call fixed it for me. I hope this is fine and you can pull it in.

best regards
cwur