### PR TITLE
Use emacs base64 sha1

### DIFF
--- a/anki-editor.el
+++ b/anki-editor.el
@@ -197,10 +197,7 @@ The result is the path to the newly stored media file."
   (unless (-all? #'executable-find '("base64" "sha1sum"))
     (error "Please make sure `base64' and `sha1sum' are available from your shell, which are required for storing media files"))
 
-  (let* ((hash (string-trim
-                (shell-command-to-string
-                 (format "sha1sum %s | awk '{print $1}'"
-                         (shell-quote-argument path)))))
+  (let* ((hash (secure-hash 'sha1 path))
          (media-file-name (format "%s-%s%s"
                                   (file-name-base path)
                                   hash

--- a/anki-editor.el
+++ b/anki-editor.el
@@ -210,10 +210,10 @@ The result is the path to the newly stored media file."
                               "retrieveMediaFile"
                               `((filename . ,media-file-name))))
       (message "Storing media file to Anki for %s..." path)
-      (setq content (string-trim
-                     (shell-command-to-string
-                      (format "base64 --wrap=0 %s"
-                              (shell-quote-argument path)))))
+      (setq content (base64-encode-string
+		     (with-temp-buffer
+		       (insert-file-contents path)
+		       (buffer-string))))
       (anki-editor--anki-connect-invoke-result
        "storeMediaFile"
        `((filename . ,media-file-name)

--- a/anki-editor.el
+++ b/anki-editor.el
@@ -194,9 +194,6 @@ See https://apps.ankiweb.net/docs/manual.html#latex-conflicts.")
 (defun anki-editor--anki-connect-store-media-file (path)
   "Store media file for PATH, which is an absolute file name.
 The result is the path to the newly stored media file."
-  (unless (-all? #'executable-find '("base64" "sha1sum"))
-    (error "Please make sure `base64' and `sha1sum' are available from your shell, which are required for storing media files"))
-
   (let* ((hash (secure-hash 'sha1 path))
          (media-file-name (format "%s-%s%s"
                                   (file-name-base path)


### PR DESCRIPTION
Using command line utilities was causing issues for me on a Mac especially `base64` which puts out something different. 

Instead of relying on those which vary across systems I think it makes sense to use built in's.