### PR TITLE
Add MathJax as an option instead of LaTeX

### DIFF
--- a/anki-editor.el
+++ b/anki-editor.el
@@ -112,6 +112,8 @@ See https://apps.ankiweb.net/docs/manual.html#latex-conflicts.")
   "8765"
   "The port number AnkiConnect is listening.")
 
+(defcustom anki-editor-use-math-jax nil
+  "Use Anki's built in MathJax support instead of LaTeX.")
 
 ;;; AnkiConnect
 
@@ -218,10 +220,15 @@ The result is the path to the newly stored media file."
 ;;; Org Export Backend
 
 (defconst anki-editor--ox-anki-html-backend
-  (org-export-create-backend
-   :parent 'html
-   :transcoders '((latex-fragment . anki-editor--ox-latex)
-                  (latex-environment . anki-editor--ox-latex))))
+  (if anki-editor-use-math-jax
+      (org-export-create-backend
+       :parent 'html
+       :transcoders '((latex-fragment . anki-editor--ox-latex-for-mathjax)
+                      (latex-environment . anki-editor--ox-latex-for-mathjax)))
+    (org-export-create-backend
+     :parent 'html
+     :transcoders '((latex-fragment . anki-editor--ox-latex)
+                    (latex-environment . anki-editor--ox-latex)))))
 
 (defconst anki-editor--ox-export-ext-plist
   '(:with-toc nil :anki-editor-mode t))
@@ -245,9 +252,28 @@ The result is the path to the newly stored media file."
           (when matched (throw 'done latex-code)))))
     latex-code))
 
+(defun anki-editor--translate-latex-delimiters-to-anki-mathjax-delimiters (latex-code)
+  (catch 'done
+    (let ((delimiter-map (list (list (cons (format "^%s" (regexp-quote "$$")) "\\[")
+                                     (cons (format "%s$" (regexp-quote "$$")) "\\]"))
+                               (list (cons (format "^%s" (regexp-quote "$")) "\\(")
+                                     (cons (format "%s$" (regexp-quote "$")) "\\)"))))
+          (matched nil))
+      (save-match-data
+        (dolist (pair delimiter-map)
+          (dolist (delimiter pair)
+            (when (setq matched (string-match (car delimiter) latex-code))
+              (setq latex-code (replace-match (cdr delimiter) t t latex-code))))
+          (when matched (throw 'done latex-code)))))
+    latex-code))
+
 (defun anki-editor--wrap-latex (content)
   "Wrap CONTENT with Anki-style latex markers."
   (format "<p><div>[latex]</div>%s<div>[/latex]</div></p>" content))
+
+(defun anki-editor--wrap-latex-for-mathjax (content)
+  "Wrap CONTENT for Anki's native MathJax support."
+  (format "<p>%s</p>" content))
 
 (defun anki-editor--wrap-div (content)
   (format "<div>%s</div>" content))
@@ -260,6 +286,22 @@ CONTENTS is nil.  INFO is a plist holding contextual information."
           (pcase (org-element-type latex)
             ('latex-fragment (anki-editor--translate-latex-delimiters code))
             ('latex-environment (anki-editor--wrap-latex
+                                 (mapconcat #'anki-editor--wrap-div
+                                            (split-string (org-html-encode-plain-text code) "\n")
+                                            "")))))
+
+    (if anki-editor-break-consecutive-braces-in-latex
+        (replace-regexp-in-string "}}" "} } " code)
+      code)))
+
+(defun anki-editor--ox-latex-for-mathjax (latex _contents _info)
+  "Transcode LATEX from Org to HTML.
+CONTENTS is nil.  INFO is a plist holding contextual information."
+  (let ((code (org-remove-indentation (org-element-property :value latex))))
+    (setq code
+          (pcase (org-element-type latex)
+            ('latex-fragment (anki-editor--translate-latex-delimiters-to-anki-mathjax-delimiters code))
+            ('latex-environment (anki-editor--wrap-latex-for-mathjax
                                  (mapconcat #'anki-editor--wrap-div
                                             (split-string (org-html-encode-plain-text code) "\n")
                                             "")))))


### PR DESCRIPTION
Anki 2.1 provides native MathJax support. This branch modifies anki-editor to be able to generate MathJax delimited math fragments analogous to how anki-editor does the same for vanilla LaTeX. This is facilitated from the user's perspective, but making one change to a customizable variable: anki-editor-use-mathjax. I haven't done extensive testing for all features of anki-editor, but it worked for my use cases just fine.