### PR TITLE
request 0.3.1 assumes utf-8

### DIFF
--- a/anki-editor.el
+++ b/anki-editor.el
@@ -5,7 +5,7 @@
 ;; Description: Make Anki Cards in Org-mode
 ;; Author: Lei Tan
 ;; Version: 0.3.3
-;; Package-Requires: ((emacs "25") (request "0.3.0") (dash "2.12.0"))
+;; Package-Requires: ((emacs "25") (request "0.3.1") (dash "2.12.0"))
 ;; URL: https://github.com/louietan/anki-editor
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/anki-editor.el
+++ b/anki-editor.el
@@ -163,7 +163,7 @@ See https://apps.ankiweb.net/docs/manual.html#latex-conflicts.")
 
 (defun anki-editor--anki-connect-invoke-multi (&rest actions)
   (-zip-with (lambda (result handler)
-               (when-let (((listp result))
+               (when-let ((_ (listp result))
                           (err (alist-get 'error result)))
                  (error err))
                (and handler (funcall handler result)))
@@ -666,7 +666,7 @@ of that heading."
        (message "[%d/%d] Processing notes in buffer \"%s\", wait a moment..."
                 (cl-incf acc) total (buffer-name))
        (anki-editor--clear-failure-reason)
-       (condition-case err
+       (condition-case-unless-debug err
            (anki-editor--push-note (anki-editor-note-at-point))
          (error (cl-incf failed)
                 (anki-editor--set-failure-reason (error-message-string err)))))

--- a/anki-editor.el
+++ b/anki-editor.el
@@ -146,20 +146,12 @@ See https://apps.ankiweb.net/docs/manual.html#latex-conflicts.")
                                      anki-editor-anki-connect-listening-port)
                              :type "POST"
                              :parser 'json-read
-                             :data (encode-coding-string request-body 'utf-8)
+                             :data request-body
                              :success (cl-function (lambda (&key data &allow-other-keys)
                                                      (setq reply data)))
                              :error (cl-function (lambda (&key _ &key error-thrown &allow-other-keys)
                                                    (setq err (string-trim (cdr error-thrown)))))
-                             :sync t)))
-
-      ;; HACK: With sync set to t, `request' waits for curl process to
-      ;; exit, then response data becomes available, but callbacks
-      ;; might not be called right away but at a later time, that's
-      ;; why here we manually invoke callbacks to receive the result.
-      (unless (request-response-done-p response)
-        (request--curl-callback (get-buffer-process (request-response--buffer response)) "finished\n")))
-
+                             :sync t))))
     (when err (error "Error communicating with AnkiConnect using cURL: %s" err))
     (or reply (error "Got empty reply from AnkiConnect"))))
 

--- a/anki-editor.el
+++ b/anki-editor.el
@@ -5,7 +5,7 @@
 ;; Description: Make Anki Cards in Org-mode
 ;; Author: Lei Tan
 ;; Version: 0.3.3
-;; Package-Requires: ((emacs "25") (request "0.3.1") (dash "2.12.0"))
+;; Package-Requires: ((emacs "25") (request "20190726") (dash "2.12.0"))
 ;; URL: https://github.com/louietan/anki-editor
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/anki-editor.el
+++ b/anki-editor.el
@@ -5,7 +5,7 @@
 ;; Description: Make Anki Cards in Org-mode
 ;; Author: Lei Tan
 ;; Version: 0.3.3
-;; Package-Requires: ((emacs "25") (request "20190726") (dash "2.12.0"))
+;; Package-Requires: ((emacs "25") (request "20190819") (dash "2.12.0"))
 ;; URL: https://github.com/louietan/anki-editor
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
The tkf library now defaults to utf-8 encoding (so does not need to be
done in anki-editor).  Further the synchronous bug has been fixed.

Closes #51 #49