### PR TITLE
Update deck for all cards of a note

### DIFF
--- a/anki-editor.el
+++ b/anki-editor.el
@@ -526,6 +526,9 @@ Where the subtree is created depends on PREFIX."
                     (cl-set-difference (anki-editor-note-tags note) :test 'string=)
                     (cl-set-difference anki-editor-protected-tags :test 'string=))))
     (anki-editor-api-with-multi
+     (anki-editor-api-enqueue 'changeDeck
+			      :cards (alist-get 'cards oldnote)
+			      :deck (anki-editor-note-deck note))
      (when tagsadd
        (anki-editor-api-enqueue 'addTags
                                 :notes (list (anki-editor-note-id note))


### PR DESCRIPTION
Getting the current deck name and only updating if the deck name
changed would introduce a third request for getting the current deck
name of the cards of a note. That's why I decided to update the deck
every time when a note is to be updated...