### PR TITLE
Make `wav` audio format recognized properly

### DIFF
--- a/anki-editor.el
+++ b/anki-editor.el
@@ -354,7 +354,7 @@ The implementation is borrowed and simplified from ox-html."
             (org-html--format-image path attributes-plist info))
 
            ;; Audio file.
-           ((string-suffix-p ".mp3" path t)
+           ((or (string-suffix-p ".mp3" path t) (string-suffix-p ".wav" path t)
               (format "[sound:%s]" path))
 
            ;; External link with a description part.


### PR DESCRIPTION
I'm using `say` command in macosx to augment pronunciation part of my flash card automatically. I found that even if Anki supports wav files as a proper audio file, this package only handles mp3. I thought, at least, wav file should be supported.