### PR TITLE
Wrap latex-environments in \[\]

### DIFF
--- a/anki-editor.el
+++ b/anki-editor.el
@@ -271,7 +271,7 @@ The result is the path to the newly stored media file."
 
 (defun anki-editor--wrap-latex-for-mathjax (content)
   "Wrap CONTENT for Anki's native MathJax support."
-  (format "<p>%s</p>" content))
+  (format "<p>\\[%s\\]</p>" content))
 
 (defun anki-editor--wrap-div (content)
   (format "<div>%s</div>" content))


### PR DESCRIPTION
These are the delimiters Mathjax uses for display equations.
I'm not sure why this isn't already done. This should be an essentially free upgrade.
org-mode example for test:

```org-mode
\begin{align}
\frac{cx + x^2}{ca^2 + ax^2} &= \frac{x(c + x)}{a^2(c + x)} \\
&= \frac{x}{a^2}
\end{align}
```