### PR TITLE
Proper line break syntax for Mathjax latex environment

### DIFF
--- a/anki-editor.el
+++ b/anki-editor.el
@@ -300,9 +300,7 @@ CONTENTS is nil.  INFO is a plist holding contextual information."
           (pcase (org-element-type latex)
             ('latex-fragment (anki-editor--translate-latex-delimiters-to-anki-mathjax-delimiters code))
             ('latex-environment (anki-editor--wrap-latex-for-mathjax
-                                 (mapconcat #'anki-editor--wrap-div
-                                            (split-string (org-html-encode-plain-text code) "\n")
-                                            "")))))
+                                 (replace-regexp-in-string "\n" "<br>\n" code)))))
 
     (if anki-editor-break-consecutive-braces-in-latex
         (replace-regexp-in-string "}}" "} } " code)

--- a/anki-editor.el
+++ b/anki-editor.el
@@ -271,7 +271,7 @@ The result is the path to the newly stored media file."
 
 (defun anki-editor--wrap-latex-for-mathjax (content)
   "Wrap CONTENT for Anki's native MathJax support."
-  (format "<p>%s</p>" content))
+  (format "<p>\\[%s\\]</p>" content))
 
 (defun anki-editor--wrap-div (content)
   (format "<div>%s</div>" content))


### PR DESCRIPTION
Current state of this package doesn't foster mathjax as a first citizen of anki's latex export. Doesn't handle environment starting with `\begin` at all for now, and even if enabling it with #91, still doesn't render properly when latex fragment contains line breaks.

This is due to the fact that the line breaks within latex environment are wrapped with `<div>,` rather than `<br>`, which is the proper one as one can see from [Anki's official document](https://docs.ankiweb.net/math.html#mathjax).

The minimal example where mathjax broke down is following.

``` latex
\begin{align*}
\forall \epsilon > 0, \exists \delta > 0, \forall y, \\
\lvert x - y \rvert < \delta \implies \lvert f(x) - f(y) \rvert < \epsilon.
\end{align*}
```

After current pull request gets merged, such fragment starts to get handled properly.